### PR TITLE
Fix flake host/username reference

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,13 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
 
-      perSystem = { system, pkgs, ... }: {
+      perSystem = { system, pkgs, ... }: let
+        username = "am";
+        hostname = "pax";
+      in {
         _module.args.pkgs = import nixpkgs { inherit system; };
-        _module.args.username = let u = builtins.getEnv "USER"; in if u == "" then "user" else u;
-        _module.args.hostname = let h = builtins.getEnv "HOSTNAME"; in if h == "" then "darwin" else h;
+        _module.args.username = username;
+        _module.args.hostname = hostname;
 
         devShells.default = pkgs.mkShell {
           buildInputs = [ pkgs.git pkgs.home-manager pkgs.nh ];


### PR DESCRIPTION
## Summary
- fix how username and hostname are determined in `flake.nix`

## Testing
- `nix flake show --no-update-lock-file` *(fails: `bash: nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68576bb2faac83248bcedba1f787f8f2